### PR TITLE
Pin Trivy action version

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -102,7 +102,8 @@ jobs:
 
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        # Use a fixed version for reproducibility
+        uses: aquasecurity/trivy-action@v0.13.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           format: 'sarif'


### PR DESCRIPTION
## Summary
- pin the `aquasecurity/trivy-action` in `docker-build.yml` to `v0.13.0`
- add a comment noting the chosen version

## Testing
- `bun test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f51003748329810c89058c6da614