### PR TITLE
Add cache-to step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           target: development
           cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Generate release notes
         run: |


### PR DESCRIPTION
## Summary
- update release workflow to push Docker cache for development image

## Testing
- `make check` *(fails: bunx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f50ceafc83298b7b6806eb168441