### PR TITLE
Fix production Docker build test cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,4 @@ jobs:
           context: .
           target: production
           cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- add missing `cache-to` option for production image build in CI workflow

## Testing
- `python - <<'EOF'...` (PyYAML validation)

------
https://chatgpt.com/codex/tasks/task_e_6866f508c3f483298794a5d11495228a